### PR TITLE
fixing tld validation in the domain part

### DIFF
--- a/lib/rfc822.rb
+++ b/lib/rfc822.rb
@@ -7,9 +7,10 @@ module RFC822
   DOMAIN_LITERAL = "\\x5b(?:#{DTEXT}|#{QUOTED_PAIR})*\\x5d"
   QUOTED_STRING = "\\x22(?:#{QTEXT}|#{QUOTED_PAIR})*\\x22"
   DOMAIN_REF = ATOM
+  TLD = "[\\x61-\\x7a]+"
   SUB_DOMAIN = "(?:#{DOMAIN_REF}|#{DOMAIN_LITERAL})"
   WORD = "(?:#{ATOM}|#{QUOTED_STRING})"
-  DOMAIN = "#{SUB_DOMAIN}(?:\\x2e#{SUB_DOMAIN})*"
+  DOMAIN = "#{SUB_DOMAIN}(?:\\x2e#{SUB_DOMAIN})*\\x2e#{TLD}"
   LOCAL_PART = "#{WORD}(?:\\x2e#{WORD})*"
   ADDR_SPEC = "#{LOCAL_PART}\\x40#{DOMAIN}"
 


### PR DESCRIPTION
Ensuring presence of the tld in the domain part.
without this modification a domain can be consider valid without the tld

e.g. : before an email like `foo@bar` will pass the validation which is not what we want.

PS : This is maybe not the best way to do it, but the need to fix this exists anyway.
If you have a better way, help yourself, I just need that the library properly validates email address.

Thanks
