### PR TITLE
Regexp.new third argument usage fix for Ruby 3.3

### DIFF
--- a/lib/rfc822.rb
+++ b/lib/rfc822.rb
@@ -13,8 +13,8 @@ module RFC822
   LOCAL_PART = "#{WORD}(?:\\x2e#{WORD})*"
   ADDR_SPEC = "#{LOCAL_PART}\\x40#{DOMAIN}"
 
-  EMAIL_REGEXP_WHOLE = Regexp.new("\\A#{ADDR_SPEC}\\z", nil, 'n')
-  EMAIL_REGEXP_PART = Regexp.new("#{ADDR_SPEC}", nil, 'n')
+  EMAIL_REGEXP_WHOLE = Regexp.new("\\A#{ADDR_SPEC}\\z", Regexp::NOENCODING)
+  EMAIL_REGEXP_PART = Regexp.new("#{ADDR_SPEC}", Regexp::NOENCODING)
 end
 
 class String


### PR DESCRIPTION
Ruby 3.2 deprecated third argument usage in Regexp.new.

Ruby 3.3 doesn't support it, this PR fixes that.

This was also done in [this other PR](https://github.com/dorianmariefr/cookiejar2/pull/2) for another gem.